### PR TITLE
Fix TUI sizing under piped stdout, release 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "interactive-semantic-hunt"
-version = "0.1.0"
+version = "0.1.1"
 description = "Interactive semantic search for code, inspired by fzf"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ish/interfaces/cli/main.py
+++ b/src/ish/interfaces/cli/main.py
@@ -4,6 +4,7 @@ Parse arguments, delegate wiring to the bootstrap module, format output.
 """
 
 import logging
+import os
 import shutil
 import sys
 
@@ -77,6 +78,29 @@ def _run_query(args: CliArgs) -> int:
     return 0
 
 
+def _sync_terminal_size() -> None:
+    """Tell Textual the real terminal size when stdout is not it.
+
+    Textual measures the terminal through stdout, which
+    `nvim $(ish -i src/)` redirects to a pipe for the selection. Reading
+    COLUMNS and LINES comes first, before Textual ever queries stdout, so
+    setting them from the terminal that stdin still faces keeps the
+    picker sized to the real window instead of a frozen 80x24 fallback.
+    """
+    if sys.stdout.isatty():
+        return
+    for stream in (sys.stdin, sys.stderr):
+        try:
+            if not stream.isatty():
+                continue
+            size = os.get_terminal_size(stream.fileno())
+        except OSError:
+            continue
+        os.environ.setdefault("COLUMNS", str(size.columns))
+        os.environ.setdefault("LINES", str(size.lines))
+        return
+
+
 def _run_tui(args: CliArgs) -> int:
     """Run the interactive TUI and print the selection to stdout.
 
@@ -85,6 +109,7 @@ def _run_tui(args: CliArgs) -> int:
     """
     from ish.interfaces.tui.app import IshApp
 
+    _sync_terminal_size()
     search_use_case = bootstrap.build_search(args.settings, args.path)
     try:
         app = IshApp(

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -348,6 +348,71 @@ class TestRefreshReportsProgress:
         assert any("Refreshing 1 of 1" in line for line in said)
 
 
+class TestTerminalSizeForPiping:
+    """Verify `nvim $(ish -i src/)` sees the real terminal, not a pipe.
+
+    Textual measures the terminal through stdout, which command
+    substitution redirects to a pipe. COLUMNS and LINES override that
+    reading, so the picker must set them from a stream that is still the
+    terminal.
+    """
+
+    def test_a_terminal_on_stdout_is_left_alone(self, monkeypatch) -> None:
+        from ish.interfaces.cli import main as cli
+
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True, raising=False)
+        cli._sync_terminal_size()
+        assert "COLUMNS" not in cli.os.environ
+
+    def test_a_piped_stdout_reads_stdin_s_terminal(self, monkeypatch) -> None:
+        from ish.interfaces.cli import main as cli
+
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.delenv("LINES", raising=False)
+        monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli.sys.stdin, "fileno", lambda: 0, raising=False)
+        monkeypatch.setattr(
+            cli.os, "get_terminal_size", lambda fd: cli.os.terminal_size((132, 43))
+        )
+        cli._sync_terminal_size()
+        assert cli.os.environ["COLUMNS"] == "132"
+        assert cli.os.environ["LINES"] == "43"
+
+    def test_falls_back_to_stderr_s_terminal(self, monkeypatch) -> None:
+        from ish.interfaces.cli import main as cli
+
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.delenv("LINES", raising=False)
+        monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr(cli.sys.stderr, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli.sys.stderr, "fileno", lambda: 2, raising=False)
+        monkeypatch.setattr(
+            cli.os, "get_terminal_size", lambda fd: cli.os.terminal_size((100, 30))
+        )
+        cli._sync_terminal_size()
+        assert cli.os.environ["COLUMNS"] == "100"
+        assert cli.os.environ["LINES"] == "30"
+
+    def test_no_terminal_anywhere_leaves_no_trace(self, monkeypatch) -> None:
+        from ish.interfaces.cli import main as cli
+
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli.sys.stdin, "fileno", lambda: 0, raising=False)
+        monkeypatch.setattr(cli.sys.stderr, "isatty", lambda: False, raising=False)
+
+        def boom(fd):
+            raise OSError("not a terminal")
+
+        monkeypatch.setattr(cli.os, "get_terminal_size", boom)
+        cli._sync_terminal_size()
+        assert "COLUMNS" not in cli.os.environ
+
+
 class TestRefreshFromTheCommandLine:
     """Verify --refresh visits the trees before the query runs."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "interactive-semantic-hunt"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- `nvim $(ish -i src/)` rendered garbled because Textual's `LinuxDriver` measures the terminal by querying stdout's file descriptor, and command substitution redirects `ish`'s stdout to a pipe. That query fails, so Textual falls back to a fixed 80x24 permanently — the same broken query fires again on every resize.
- `_sync_terminal_size()` in `src/ish/interfaces/cli/main.py` now sets `COLUMNS`/`LINES` from whichever of stdin or stderr is still a real terminal, before the TUI starts. `shutil.get_terminal_size()` (which Textual calls internally) reads those variables before it ever touches stdout, so the picker gets the real window size.
- Bumps the version to 0.1.1 for release.

## Test plan

- [x] Added unit tests in `tests/integration/cli/test_cli.py` covering: a real terminal on stdout (no-op), falling back to stdin's size, falling back to stderr's size, and no terminal anywhere (no crash).
- [x] `uv run poe check` (lint, typecheck, full test suite) — green aside from 5 pre-existing failures unrelated to this change (permission-based tests that don't hold under a root test runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd)_