### PR TITLE
Release automatically when a milestone closes

### DIFF
--- a/.github/workflows/release-on-milestone.yml
+++ b/.github/workflows/release-on-milestone.yml
@@ -1,0 +1,77 @@
+name: release-on-milestone
+
+# Ships whatever a closed milestone names. Closing a milestone is the
+# decision to release it, the same way pushing a tag is the decision to
+# publish it — nothing here runs on any other event.
+on:
+  milestone:
+    types: [closed]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MILESTONE_TITLE: ${{ github.event.milestone.title }}
+      MILESTONE_NUMBER: ${{ github.event.milestone.number }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Read the version from the milestone title
+        run: |
+          if ! [[ "$MILESTONE_TITLE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Milestone title '$MILESTONE_TITLE' is not a plain X.Y.Z version; refusing to release." >&2
+            exit 1
+          fi
+          echo "VERSION=$MILESTONE_TITLE" >> "$GITHUB_ENV"
+
+      - name: Refuse a milestone that still has open issues
+        run: |
+          open=$(gh api "repos/${{ github.repository }}/milestones/$MILESTONE_NUMBER" --jq .open_issues)
+          if [ "$open" -ne 0 ]; then
+            echo "Milestone $MILESTONE_TITLE still has $open open issue(s); refusing to release." >&2
+            exit 1
+          fi
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Write the version into pyproject.toml, and relock
+        run: |
+          python - <<'PY'
+          import os, pathlib, re
+
+          version = os.environ["VERSION"]
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text()
+          new_text, count = re.subn(
+              r'(?m)^version = ".*"$', f'version = "{version}"', text, count=1
+          )
+          if count != 1:
+              raise SystemExit("Could not find a version line in pyproject.toml")
+          path.write_text(new_text)
+          PY
+          uv lock
+
+      - run: uv sync --dev
+      - run: uv run poe check
+
+      - name: Commit, tag, and push straight to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "Release $VERSION"
+          git tag "v$VERSION"
+          git push origin main
+          git push origin "v$VERSION"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,14 +22,26 @@ there is no token to leak or rotate.
 
 ## Each release
 
+Close the milestone. `release-on-milestone.yml` reads the version from the
+milestone's own title (it must be a plain `X.Y.Z`, so a milestone that
+is not meant as a release cannot be closed by mistake into one), refuses
+if the milestone still has open issues, writes that version into
+`pyproject.toml`, relocks, runs `poe check`, and pushes the commit and
+tag to `main` itself. `release.yml` then takes over from the tag, exactly
+as it would for a tag pushed by hand.
+
+A release that does not correspond to a milestone — a hotfix, or a patch
+made outside the current cycle — has no milestone to close, so do the
+same four steps yourself:
+
 1. Decide the version and set it in `pyproject.toml`.
 2. `uv run poe check` — the release workflow runs it again, and refuses
    a tag whose name disagrees with the version it finds.
 3. Commit, then tag and push:
 
    ```sh
-   git commit -am "Release 0.1.0"
-   git tag v0.1.0
+   git commit -am "Release 0.1.1"
+   git tag v0.1.1
    git push origin main --tags
    ```
 


### PR DESCRIPTION
## Summary

- New `.github/workflows/release-on-milestone.yml`, triggered on `milestone: closed`. It takes the milestone's own title as the version (refusing anything that isn't a plain `X.Y.Z`, so closing a non-release milestone can't ship), refuses if the milestone still has open issues, bumps `pyproject.toml`, runs `uv lock` to keep the lockfile in step, runs `poe check`, and pushes the commit + tag straight to `main`.
- The existing tag-triggered `release.yml` is untouched — it still does the actual build and PyPI publish once a `v*` tag lands, whether pushed by hand or by this workflow.
- `RELEASING.md` now documents "close the milestone" as the release step for anything tracked by one, and keeps the manual steps as the documented fallback for a release with no milestone to close (a hotfix, like 0.1.1).

This deliberately does not use commitizen or any commit-message-driven version inference — the milestone title is the single source of truth for the version, matching how this repo already tracks work.

## Note

`contents: write` lets this workflow push to `main` and create tags directly — the same thing a maintainer does by hand today per `RELEASING.md`, just automated. Worth a look before merging, since it's a new capability for a bot rather than a bugfix.

## Test plan

- [x] Validated the workflow YAML parses, and the embedded Python heredoc compiles on its own (the indentation inside a `run: |` block plus a `<<'PY'` heredoc is easy to get wrong).
- [ ] Not yet exercised against a real milestone close — the first real run will be the actual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd)_