### PR TITLE
Let cut-release run by hand to bump a patch version

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Milestones are read through the issues API, and naming any scope
+      # here sets every other one to none.
+      issues: read
     env:
       GH_TOKEN: ${{ github.token }}
       MILESTONE_TITLE: ${{ github.event.milestone.title }}
@@ -33,9 +36,12 @@ jobs:
       - name: Decide the version to release
         run: |
           if [ "${{ github.event_name }}" = "milestone" ]; then
-            VERSION="$MILESTONE_TITLE"
+            # Accept "0.2.0" and "v0.2.0" alike; the tag grows its own v.
+            VERSION="${MILESTONE_TITLE#v}"
           else
-            current=$(grep -m1 '^version = "' pyproject.toml | sed -E 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"$/\1/')
+            # Let the guard below report an unreadable file, rather than
+            # letting pipefail kill the step with nothing to read.
+            current=$(grep -m1 '^version = "' pyproject.toml | sed -E 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"$/\1/') || true
             if [ -z "$current" ]; then
               echo "Could not read the current version out of pyproject.toml." >&2
               exit 1
@@ -58,13 +64,31 @@ jobs:
             exit 1
           fi
 
+      # A release carries whatever reached main since the last tag, so say
+      # what that is. A release nobody can read afterwards is one nobody
+      # can tell went out wrong.
+      - name: Say what this release contains
+        run: |
+          last=$(git describe --tags --abbrev=0 2>/dev/null) || true
+          {
+            if [ -n "$last" ]; then
+              echo "## $VERSION, everything since $last"
+              echo
+              git log --no-merges --pretty='- %s' "$last..HEAD"
+            else
+              echo "## $VERSION, the first tagged release"
+              echo
+              git log --no-merges --pretty='- %s'
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Write the version into pyproject.toml, and relock
         run: |
-          python - <<'PY'
+          uv run --no-project python - <<'PY'
           import os, pathlib, re
 
           version = os.environ["VERSION"]

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,11 +1,15 @@
-name: release-on-milestone
+name: cut-release
 
-# Ships whatever a closed milestone names. Closing a milestone is the
-# decision to release it, the same way pushing a tag is the decision to
-# publish it — nothing here runs on any other event.
+# Ships a version named by a closed milestone, or a patch bump run by
+# hand for a fix that cannot wait for one — a milestone still open is
+# not a gap in the process, it is most of development, so nothing here
+# infers a release from that on its own. Both paths land on the same
+# bump-relock-check-tag-push pipeline; only how the version is decided
+# differs.
 on:
   milestone:
     types: [closed]
+  workflow_dispatch: {}
 
 concurrency:
   group: release
@@ -26,15 +30,27 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Read the version from the milestone title
+      - name: Decide the version to release
         run: |
-          if ! [[ "$MILESTONE_TITLE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Milestone title '$MILESTONE_TITLE' is not a plain X.Y.Z version; refusing to release." >&2
+          if [ "${{ github.event_name }}" = "milestone" ]; then
+            VERSION="$MILESTONE_TITLE"
+          else
+            current=$(grep -m1 '^version = "' pyproject.toml | sed -E 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"$/\1/')
+            if [ -z "$current" ]; then
+              echo "Could not read the current version out of pyproject.toml." >&2
+              exit 1
+            fi
+            IFS='.' read -r major minor patch <<< "$current"
+            VERSION="$major.$minor.$((patch + 1))"
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version '$VERSION' is not a plain X.Y.Z; refusing to release." >&2
             exit 1
           fi
-          echo "VERSION=$MILESTONE_TITLE" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Refuse a milestone that still has open issues
+        if: github.event_name == 'milestone'
         run: |
           open=$(gh api "repos/${{ github.repository }}/milestones/$MILESTONE_NUMBER" --jq .open_issues)
           if [ "$open" -ne 0 ]; then

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@ there is no token to leak or rotate.
 
 ## Each release
 
-Close the milestone. `release-on-milestone.yml` reads the version from the
+Close the milestone. `cut-release.yml` reads the version from the
 milestone's own title (it must be a plain `X.Y.Z`, so a milestone that
 is not meant as a release cannot be closed by mistake into one), refuses
 if the milestone still has open issues, writes that version into
@@ -30,9 +30,19 @@ if the milestone still has open issues, writes that version into
 tag to `main` itself. `release.yml` then takes over from the tag, exactly
 as it would for a tag pushed by hand.
 
-A release that does not correspond to a milestone — a hotfix, or a patch
-made outside the current cycle — has no milestone to close, so do the
-same four steps yourself:
+## A release outside the milestone
+
+A fix that cannot wait for the milestone it belongs to has no milestone to
+close. Merge it to `main` as a normal PR, then run `cut-release.yml` by
+hand from the **Actions** tab (or `gh workflow run cut-release.yml`). With
+no milestone behind it, it reads the current version out of
+`pyproject.toml` and bumps the patch number itself — `0.1.1` becomes
+`0.1.2` — then runs the same relock-check-tag-push pipeline. Nothing
+infers *whether* to release this way; that is still a decision someone
+makes by running the workflow. It only removes the hand-editing once
+that decision is made.
+
+If the workflow itself cannot run, fall back to its four steps by hand:
 
 1. Decide the version and set it in `pyproject.toml`.
 2. `uv run poe check` — the release workflow runs it again, and refuses
@@ -40,8 +50,8 @@ same four steps yourself:
 3. Commit, then tag and push:
 
    ```sh
-   git commit -am "Release 0.1.1"
-   git tag v0.1.1
+   git commit -am "Release 0.1.2"
+   git tag v0.1.2
    git push origin main --tags
    ```
 


### PR DESCRIPTION
## Summary

- Renamed `release-on-milestone.yml` → `cut-release.yml` (it now does more than react to a milestone) and added a `workflow_dispatch` trigger alongside the existing `milestone: closed` one.
- Run by hand (Actions tab, or `gh workflow run cut-release.yml`), it reads the current version straight out of `pyproject.toml` and bumps the patch number itself — no version to type, no hand-editing. It then runs through the exact same relock → `poe check` → commit → tag → push pipeline the milestone path already uses.
- The "still has open issues" guard only applies to the milestone path (`if: github.event_name == 'milestone'`) — a manual patch bump has no milestone to check against.
- `RELEASING.md` documents this as the path for a release outside the milestone cycle (a hotfix, like 0.1.1 was), and keeps the fully-manual steps only as a last resort for when the workflow itself can't run.

Deliberately does **not** add any automatic trigger for this — no schedule, no "release on every push to main". A milestone still being open is normal, ongoing development, not a signal to ship; a patch bump only ever happens because someone runs the workflow.

## Test plan

- [x] Validated the committed workflow YAML parses.
- [x] Extracted and ran the patch-bump shell logic against this repo's real `pyproject.toml` (`0.1.1` → `0.1.2`, format check passes).
- [ ] Not yet exercised as a real `workflow_dispatch` run — the first manual trigger will be the actual test, same as the milestone path was before its first real close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd)_