### PR TITLE
Tag a version that pyproject.toml already declares

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,6 +32,10 @@ poe release 0.2.0   # the version a milestone names
 poe release         # raise the patch number
 ```
 
+Naming the version `pyproject.toml` already declares tags that version
+instead of raising it. A release prepared and never tagged is a release
+still owed, and it takes the same checks as any other.
+
 It does not push. Pushing the tag is the decision to publish, and it is
 the only thing that reaches PyPI:
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -3,6 +3,10 @@
     poe release          # raise the patch number
     poe release 0.2.0    # release exactly this version
 
+Naming the version pyproject.toml already declares tags that version
+rather than raising it, because a release prepared and never tagged is
+a release still owed.
+
 Leave the tag unpushed. Pushing it is the decision to publish, and
 `release.yml` takes over from there.
 
@@ -58,6 +62,13 @@ def next_patch(version: str) -> str:
     return f"{major}.{minor}.{int(patch) + 1}"
 
 
+def is_after(version: str, other: str) -> bool:
+    """Return whether *version* stands later than *other*."""
+    return tuple(int(part) for part in version.split(".")) > tuple(
+        int(part) for part in other.split(".")
+    )
+
+
 def git(*arguments: str) -> str:
     """Run one git command and return what it said."""
     done = subprocess.run(
@@ -93,8 +104,18 @@ def cut(asked: str | None) -> str:
     if git("tag", "--list", f"v{version}"):
         raise ReleaseError(f"v{version} exists already")
 
-    print(f"Releasing {current} -> {version}\n")
-    PYPROJECT.write_text(set_version(text, version), encoding="utf-8")
+    # A version already declared is a release that was prepared and never
+    # tagged. Prove it and tag it: there is nothing left to write.
+    bumping = version != current
+    if bumping and not is_after(version, current):
+        raise ReleaseError(f"{version} does not come after the declared {current}")
+
+    if bumping:
+        print(f"Releasing {current} -> {version}\n")
+        PYPROJECT.write_text(set_version(text, version), encoding="utf-8")
+    else:
+        print(f"{version} is declared already, so proving it and tagging it\n")
+
     try:
         lock()
         check()
@@ -104,7 +125,10 @@ def cut(asked: str | None) -> str:
         git("checkout", "--", str(PYPROJECT), "uv.lock")
         raise
 
-    git("commit", "-am", f"Release {version}")
+    # Commit whatever changed. A version already declared leaves nothing to
+    # commit, unless relocking moved the lock file.
+    if git("status", "--porcelain"):
+        git("commit", "-am", f"Release {version}")
     git("tag", f"v{version}")
     return version
 

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -68,6 +68,102 @@ class TestSetVersion:
             release.set_version('name = "x"\n', "0.2.0")
 
 
+class TestIsAfter:
+    """Verify which way round two versions stand."""
+
+    def test_a_later_patch_comes_after(self) -> None:
+        assert release.is_after("0.1.2", "0.1.1")
+
+    def test_a_later_minor_comes_after(self) -> None:
+        assert release.is_after("0.2.0", "0.1.9")
+
+    def test_the_same_version_comes_after_nothing(self) -> None:
+        assert not release.is_after("0.1.1", "0.1.1")
+
+    def test_an_earlier_version_does_not(self) -> None:
+        assert not release.is_after("0.1.0", "0.2.0")
+
+
+@pytest.fixture()
+def repository(tmp_path, monkeypatch):
+    """Build a throwaway repository declaring 0.1.1, and work inside it."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.1.1"\n')
+    (tmp_path / "uv.lock").write_text("version = 1\n")
+    monkeypatch.chdir(tmp_path)
+    release.git("init", "-q")
+    release.git("config", "user.email", "test@example.com")
+    release.git("config", "user.name", "Test")
+    release.git("add", ".")
+    release.git("commit", "-qm", "First")
+    # Neither belongs in a test: one reaches the network, the other runs
+    # the whole suite again.
+    monkeypatch.setattr(release, "lock", lambda: None)
+    monkeypatch.setattr(release, "check", lambda: None)
+    return tmp_path
+
+
+class TestCut:
+    """Verify what a release writes, commits, and tags."""
+
+    def test_a_version_already_declared_is_tagged_not_raised(self, repository) -> None:
+        """Tag a release that was prepared and never tagged.
+
+        Committing is what used to fail here: nothing had changed, so git
+        refused, and the release could not be cut at all.
+        """
+        before = release.git("rev-parse", "HEAD")
+
+        assert release.cut("0.1.1") == "0.1.1"
+
+        assert release.git("tag", "--list") == "v0.1.1"
+        assert release.git("rev-parse", "HEAD") == before, "committed with no change"
+        assert 'version = "0.1.1"' in (repository / "pyproject.toml").read_text()
+
+    def test_a_leading_v_names_the_same_version(self, repository) -> None:
+        assert release.cut("v0.1.1") == "0.1.1"
+        assert release.git("tag", "--list") == "v0.1.1"
+
+    def test_raising_the_patch_writes_and_commits(self, repository) -> None:
+        before = release.git("rev-parse", "HEAD")
+
+        assert release.cut(None) == "0.1.2"
+
+        assert release.git("tag", "--list") == "v0.1.2"
+        assert release.git("rev-parse", "HEAD") != before
+        assert release.git("log", "-1", "--pretty=%s") == "Release 0.1.2"
+        assert 'version = "0.1.2"' in (repository / "pyproject.toml").read_text()
+
+    def test_refuses_to_go_backwards(self, repository) -> None:
+        with pytest.raises(release.ReleaseError, match="does not come after"):
+            release.cut("0.1.0")
+        assert release.git("tag", "--list") == ""
+
+    def test_refuses_a_tag_that_exists(self, repository) -> None:
+        release.git("tag", "v0.2.0")
+        with pytest.raises(release.ReleaseError, match="exists already"):
+            release.cut("0.2.0")
+
+    def test_refuses_a_working_tree_with_changes(self, repository) -> None:
+        (repository / "pyproject.toml").write_text('[project]\nversion = "0.9.9"\n')
+        with pytest.raises(release.ReleaseError, match="commit or stash"):
+            release.cut(None)
+
+    def test_a_failing_check_writes_nothing(self, repository, monkeypatch) -> None:
+        """Leave the tree as it was found when the checks do not pass."""
+
+        def boom() -> None:
+            raise release.ReleaseError("poe check failed")
+
+        monkeypatch.setattr(release, "check", boom)
+
+        with pytest.raises(release.ReleaseError, match="poe check failed"):
+            release.cut(None)
+
+        assert 'version = "0.1.1"' in (repository / "pyproject.toml").read_text()
+        assert release.git("tag", "--list") == ""
+        assert release.git("status", "--porcelain") == ""
+
+
 class TestTheRealProjectFile:
     """Verify the script reads the file it is actually pointed at."""
 


### PR DESCRIPTION
## Summary

`poe release 0.1.1` could not cut a release when `pyproject.toml` already declared `0.1.1`. It wrote the same version back, nothing changed, and `git commit -am` then refused a commit with no change — so the run died with a git error instead of tagging.

That is not an exotic state. It is exactly what an abandoned release leaves behind, and `main` has been sitting in it: `0.1.1` was bumped and committed but never tagged.

- **A version already declared is now tagged rather than raised**, after the same `uv lock` and `poe check` every other release gets. There is nothing left to write, so nothing is written.
- **Commit only what actually changed.** One rule covers both paths, including a relock that moves `uv.lock` on its own.
- **Refuse a version that does not come after the declared one.** Added while reconciling asked-versus-declared, since the equality case is the same question — and publishing backwards cannot be undone on PyPI. Say the word if you'd rather I drop it; it's `is_after()` plus three lines in `cut()`.
- `RELEASING.md` documents the behaviour.

## Test plan

- [x] **`cut()` is now tested against a throwaway git repository** — which is the whole reason this stopped being a workflow. Covers: tagging an already-declared version without committing, a leading `v`, raising the patch and committing, refusing a backwards version, refusing an existing tag, refusing a dirty tree, and leaving the tree untouched when the checks fail.
- [x] **Mutation-tested.** Restoring the old unconditional `git commit` fails both new tests; putting the guard back makes them pass. The fix is pinned, not just present.
- [x] `poe lint`, `poe typecheck` clean over `src tests scripts`. Full suite: 903 passed, with the same 5 pre-existing failures that fail on `main` unchanged (permission tests that don't hold under a root test runner).

After this merges, `poe release 0.1.1` on `main` is a valid way to cut the outstanding release — though `git tag v0.1.1 && git push origin v0.1.1` still does the same thing in one line, since the version is already committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQEetCDX2dHKfSzF93TjRd)_