### PR TITLE
Build the 0.1.2 milestone: a guarded release path

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# Group the notes GitHub generates under the labels this repository
+# already uses. CHANGELOG.md stays the source of a release body; this is
+# a cross-check, so a generated list that disagrees with the written
+# entry says a change reached main without a line.
+changelog:
+  exclude:
+    labels: ["release"]
+  categories:
+    - title: Indexing
+      labels: ["indexing"]
+    - title: Speed
+      labels: ["speed"]
+    - title: Interfaces
+      labels: ["interfaces"]
+    - title: Project
+      labels: ["project"]
+    - title: Other
+      labels: ["*"]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,3 +55,37 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  version:
+    # A version bump is a release, and a release is its own pull request.
+    # Bundling one with the work it was cut for is what put the 0.1.1
+    # bump in the same pull request as the fix it shipped.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Refuse a version bump outside a release
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if ! git diff "$BASE_SHA...HEAD" -- pyproject.toml |
+               grep -q '^[+-]version = '; then
+            echo "This pull request leaves the version alone."
+            exit 0
+          fi
+          case "$HEAD_REF" in
+            release/*|hotfix/*) echo "A release branch may set it."; exit 0 ;;
+          esac
+          case ",$LABELS," in
+            *,release,*) echo "The release label says this is one."; exit 0 ;;
+          esac
+          echo "::error::This pull request changes the version in pyproject.toml."
+          echo "A version bump belongs in its own pull request, opened once"
+          echo "everything for the release already sits on main. Cut it from a"
+          echo "release/X.Y.Z or hotfix/X.Y.Z branch, or add the release label."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,32 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      # Only this job writes to the repository. The publish job keeps
+      # id-token alone, so a token that can write is never in scope
+      # where a package is signed.
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      # Take the body from CHANGELOG.md. A release page and a changelog
+      # written separately drift, and the release gets written twice.
+      - name: Take the notes from the changelog
+        run: python3 scripts/release.py --notes "$GITHUB_REF_NAME" > notes.md
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: notes.md
+          # Publish the files PyPI received. Building again would make
+          # a wheel that is not the one anybody installed.
+          files: dist/*
+          # A tag naming anything but X.Y.Z is not the current version.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+Everything a reader of the tool would want to know about a release, written
+when the change is made rather than scraped from it afterwards.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the version numbers follow [Semantic Versioning](https://semver.org/).
+
+## Unreleased
+
+### Added
+
+- Keep this changelog. `poe release` names the `Unreleased` heading for the
+  version it cuts, and refuses a release that has nothing under it.
+- Publish a GitHub release beside the upload to PyPI, carrying the wheel, the
+  sdist, and the notes for that version.
+- Group the generated release notes under the labels the repository already
+  uses: `indexing`, `speed`, `interfaces`, and `project`.
+- Ship `CHANGELOG.md` in the sdist, and name it from the project links, so a
+  reader who installs from PyPI can find it.
+
+### Changed
+
+- Refuse a pull request that changes the version unless it is a release. A
+  version bump is its own pull request; it does not travel with the work that
+  motivated it.
+
+### Documentation
+
+- Say how to keep generated code out of an index, with a worked pattern.
+
+## 0.1.1 - 2026-09-05
+
+### Fixed
+
+- Size the interactive view to the terminal, not to a pipe. With stdout piped,
+  `ish -i` read the wrong width and drew to it.
+
+### Changed
+
+- Cut a release with `poe release` rather than a workflow, so the tag is made
+  where the version is set.
+- Make the terminal-size tests fail when the code is wrong.
+
+## 0.1.0 - 2026-09-03
+
+### Added
+
+- Search code by meaning, over four interfaces that share one index: the
+  command line, an interactive picker, an MCP server, and a Python API.
+- Keep the index in SQLite, one file for each tree. Key a vector by content and
+  model, so a rename embeds nothing again and a change of model keeps both
+  sets.
+- Read Python, Markdown, AsciiDoc, C, and C++. A language is one module and one
+  registry entry.
+- Rank by a vector order fused with a BM25 order, gated to a query that names
+  something.
+- Narrow a search from the query itself, with `lang:`, `under:`, and `type:`.
+- Configure from defaults, a user file, a project file, the environment, and
+  the command line, in that order.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and the version numbers follow [Semantic Versioning](https://semver.org/).
 ### Documentation
 
 - Say how to keep generated code out of an index, with a worked pattern.
+- Name the config file correctly. The documentation said `ish.toml`, which is
+  read second for compatibility; the file to write is `.ish/config.toml`, and
+  `~/.config/ish/config.toml` for a user default. Say also that every config
+  file from the target path upward applies, each settling only the keys it
+  names.
 
 ## 0.1.1 - 2026-09-05
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ resident, so a query costs about 58 ms rather than a process start.
 
 A call may narrow one search with `lang`, `under`, `type`, and `limit`, or
 write the same filters into the query text. It cannot change
-what is indexed — those settings come from `ish.toml` only, so no single call can
-shrink an index that another call depends on.
+what is indexed — those settings come from the config file only, so no single
+call can shrink an index that another call depends on.
 
 ## Index
 
@@ -233,8 +233,9 @@ means they always show the current content.
 
 ## Configure
 
-Every command-line option is also a key in `ish.toml`, under the same name.
-Put project settings in `ish.toml` at the root of your repository:
+Every command-line option is also a key in the config file, under the same
+name. Put project settings in `.ish/config.toml` at the root of your
+repository:
 
 ```toml
 embedder = "ollama"
@@ -303,11 +304,26 @@ ish "installation steps" --lang markdown asciidoc
 ish "parse a header" --under '/include/'
 ```
 
-User-level defaults go in `~/.config/ish/ish.toml`. Later sources win:
+User-level defaults go in `~/.config/ish/config.toml`, which honors
+`XDG_CONFIG_HOME`. Later sources win:
 
 ```
-defaults < ~/.config/ish/ish.toml < ./ish.toml < ISH_* environment < command line
+defaults
+  < ~/.config/ish/config.toml
+  < .ish/config.toml            (every one from the target path upward)
+  < ISH_* environment
+  < command line
 ```
+
+A flat `ish.toml` is still read, beside `.ish/config.toml` and in the user
+directory alike, so a file written before this keeps working. Prefer
+`.ish/config.toml`: it keeps a tree's settings beside anything else the tool
+leaves there.
+
+**Every** config file from the target path upward applies, outermost first, and
+each settles only the keys it names. So a file beside a subtree adds to the one
+above it rather than replacing it — a subtree can set `git = false` for itself
+and still inherit the `type_patterns` the repository above it set.
 
 Set any option from the environment with the `ISH_` prefix, for example
 `ISH_LIMIT=20` or `ISH_IGNORE=build,dist`.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,48 @@ matches at any depth and alternation works. `exclude` wins over `include`.
 `--git` is on by default, so anything a `.gitignore` covers stays out of the
 index. Pass `--no-git` to index it anyway.
 
+### Keep generated code out
+
+Generated code is the one thing worth excluding by hand. It is large, it is
+repetitive, and nobody searches it by meaning. On one firmware tree, generated
+headers were **99% of the oversized C and C++ text**: 10.3 MB of 10.4 MB, and
+the largest single definition held 2,949,177 characters. A 26 MB generated JSON
+register map produced 32,768 chunks and took 76 seconds to parse.
+
+Embedding costs about one chunk per second, so that is hours of work for text
+no query wants.
+
+Name the patterns in `exclude`:
+
+```toml
+exclude = [
+    "/generated/",           # a directory that holds nothing written by hand
+    "_pb2\\.py$",             # protobuf
+    "\\.g\\.(c|h|cpp)$",       # a generator's own suffix
+    "/build/",               # anything a build wrote
+    "register_map.*\\.json$", # a generated register map
+]
+```
+
+Two things to know:
+
+- `exclude` is index scope, so it decides what is *in* the index. Narrowing it
+  later does not remove what a wider run already stored; run `--reindex` for
+  that.
+- A pattern is a regular expression searched against the whole path, so
+  `/generated/` matches at any depth and needs no wildcards.
+
+Check a pattern before you pay to index it. An empty query lists what the
+filter allows, and `--no-cache` keeps the trial out of the stored index:
+
+```sh
+ish "" . --no-cache | wc -l                          # everything today
+ish "" . --no-cache --exclude '/generated/' | wc -l  # what the pattern leaves
+```
+
+If most of a tree is generated, it is usually less work to exclude the
+directory than to name each suffix.
+
 `--lang` and `--under` narrow what a search *returns*. They never change what is
 indexed, so a narrowed query cannot shrink the index:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,11 +59,33 @@ Naming the version `pyproject.toml` already declares tags that version
 instead of raising it. A release prepared and never tagged is a release
 still owed, and it takes the same checks as any other.
 
-It does not push. Pushing the tag is the decision to publish, and it is
-the only thing that reaches PyPI:
+It does not push, and the bump does not reach `main` on its own. A
+version bump is its own pull request, like any other change:
 
 ```sh
-git push origin main v0.2.0
+git switch -c release/0.2.0
+poe release 0.2.0
+git push origin release/0.2.0        # the branch, not the tag
+gh pr create --label release
+```
+
+The `release/` prefix, and the `release` label, are what let the
+`version` check accept a pull request that changes the version.
+
+**Merge it with a merge commit.** `poe release` tags the commit it made,
+so a squash or a rebase would leave the tag naming a commit that is not
+on `main`. Prove it before pushing:
+
+```sh
+git switch main && git pull
+git merge-base --is-ancestor v0.2.0 main && echo "the tag is on main"
+```
+
+Pushing the tag is the decision to publish, and it is the only thing
+that reaches PyPI:
+
+```sh
+git push origin v0.2.0
 ```
 
 Watch the run. The publish job waits on the build job, so a failing

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,12 +20,35 @@ there is no token to leak or rotate.
 3. In GitHub, open **Settings → Environments** and add an environment
    named `pypi`. Require a reviewer if a release should need approval.
 
+## Every pull request
+
+Write the change into `CHANGELOG.md`, under `## Unreleased`, in the pull
+request that makes it. One line, for a reader of the tool rather than a
+reviewer of the diff. A pull request title says what the work was; a
+changelog line says what the release gives.
+
+Label the pull request `indexing`, `speed`, `interfaces`, or `project`.
+The release page groups the generated list under those headings, which
+is what makes a missing changelog line visible.
+
+Never change the version. A version bump is its own pull request, opened
+once everything for the release already sits on `main`; it does not
+travel with the work that motivated it. The `version` check refuses any
+other pull request that touches it, so the rule is enforced rather than
+remembered. A `release/*` or `hotfix/*` branch, or the `release` label,
+says a pull request is the bump.
+
 ## Each release
 
 `poe release` cuts one. It refuses a working tree with changes in it,
-writes the version into `pyproject.toml`, brings `uv.lock` in step, runs
-`poe check`, then commits and tags. A check that fails puts both files
-back and commits nothing.
+names the `## Unreleased` heading for the version and dates it, writes
+the version into `pyproject.toml`, brings `uv.lock` in step, runs
+`poe check`, then commits and tags. A check that fails puts all three
+files back and commits nothing.
+
+It also refuses a release with nothing under `## Unreleased`. A release
+that says nothing is either empty or missing a line, and both need a
+person to decide which.
 
 ```sh
 poe release 0.2.0   # the version a milestone names
@@ -46,6 +69,11 @@ git push origin main v0.2.0
 Watch the run. The publish job waits on the build job, so a failing
 check never reaches PyPI, and the workflow refuses a tag whose name
 disagrees with the version it finds in `pyproject.toml`.
+
+The release job runs last and publishes the GitHub release page: the
+same wheel and sdist PyPI received, and a body taken from this version's
+`CHANGELOG.md` entry. Nothing is built a second time, so the files on
+the release page are the files people install.
 
 Nothing releases on its own. Closing a milestone says the work is done;
 running `poe release` says to ship it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/davetothek/interactive-semantic-hunt"
+Changelog = "https://github.com/davetothek/interactive-semantic-hunt/blob/main/CHANGELOG.md"
 Repository = "https://github.com/davetothek/interactive-semantic-hunt"
 Issues = "https://github.com/davetothek/interactive-semantic-hunt/issues"
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -20,14 +20,17 @@ from that tag rather than from main:
 """
 
 import argparse
+import datetime
 import re
 import subprocess
 import sys
 from pathlib import Path
 
 PYPROJECT = Path("pyproject.toml")
+CHANGELOG = Path("CHANGELOG.md")
 VERSION_LINE = re.compile(r'(?m)^version = "(.*)"$')
 SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+UNRELEASED = "## Unreleased"
 
 
 class ReleaseError(Exception):
@@ -67,6 +70,42 @@ def is_after(version: str, other: str) -> bool:
     return tuple(int(part) for part in version.split(".")) > tuple(
         int(part) for part in other.split(".")
     )
+
+
+def section(text: str, heading: str) -> str:
+    """Return what stands under *heading*, up to the next one.
+
+    Match the heading and its version alone, so `## 0.1.1 - 2026-09-05`
+    answers to `## 0.1.1` and `## 0.1.10 - ...` does not. The rest of the
+    heading line must start with a space, which is what keeps one version
+    from answering for a longer one that begins with it.
+    """
+    wanted = re.compile(
+        rf"(?m)^{re.escape(heading)}(?: [^\n]*)?\n(.*?)(?=^## |\Z)", re.DOTALL
+    )
+    found = wanted.search(text)
+    return found.group(1).strip() if found else ""
+
+
+def promote(text: str, version: str, today: str) -> str:
+    """Return *text* with the Unreleased entries named for *version*.
+
+    Leave an empty Unreleased heading above, so the next change has
+    somewhere to go without anyone making the heading first.
+    """
+    if UNRELEASED not in text:
+        raise ReleaseError(f"CHANGELOG.md has no {UNRELEASED} heading")
+    if not section(text, UNRELEASED):
+        raise ReleaseError(
+            f"CHANGELOG.md has nothing under {UNRELEASED}; "
+            "a release says what it changed"
+        )
+    return text.replace(UNRELEASED, f"{UNRELEASED}\n\n## {version} - {today}", 1)
+
+
+def today() -> str:
+    """Return today's date, as a changelog heading writes it."""
+    return datetime.date.today().isoformat()
 
 
 def git(*arguments: str) -> str:
@@ -110,10 +149,19 @@ def cut(asked: str | None) -> str:
     if bumping and not is_after(version, current):
         raise ReleaseError(f"{version} does not come after the declared {current}")
 
+    if not CHANGELOG.exists():
+        raise ReleaseError("CHANGELOG.md is missing, so this release says nothing")
+    notes = CHANGELOG.read_text(encoding="utf-8")
+
     if bumping:
         print(f"Releasing {current} -> {version}\n")
+        # Name the entries before writing the version, so a changelog with
+        # nothing under Unreleased stops the release with the tree untouched.
+        CHANGELOG.write_text(promote(notes, version, today()), encoding="utf-8")
         PYPROJECT.write_text(set_version(text, version), encoding="utf-8")
     else:
+        if not section(notes, f"## {version}"):
+            raise ReleaseError(f"CHANGELOG.md has no entry for {version}")
         print(f"{version} is declared already, so proving it and tagging it\n")
 
     try:
@@ -122,7 +170,7 @@ def cut(asked: str | None) -> str:
     except ReleaseError:
         # Put back only what this script just wrote. The tree was clean
         # above, so there is nothing else here to lose.
-        git("checkout", "--", str(PYPROJECT), "uv.lock")
+        git("checkout", "--", str(PYPROJECT), "uv.lock", str(CHANGELOG))
         raise
 
     # Commit whatever changed. A version already declared leaves nothing to
@@ -144,7 +192,23 @@ def main(argv: list[str] | None = None) -> int:
         nargs="?",
         help="Version to release. Omit it to raise the patch number.",
     )
+    parser.add_argument(
+        "--notes",
+        metavar="VERSION",
+        help="Print this version's changelog entry and stop. The release "
+        "workflow takes a release body from it, so the page and the file "
+        "cannot disagree.",
+    )
     arguments = parser.parse_args(argv)
+
+    if arguments.notes:
+        wanted = arguments.notes.removeprefix("v")
+        found = section(CHANGELOG.read_text(encoding="utf-8"), f"## {wanted}")
+        if not found:
+            print(f"release: CHANGELOG.md has no entry for {wanted}", file=sys.stderr)
+            return 1
+        print(found)
+        return 0
 
     try:
         version = cut(arguments.version)

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -89,6 +89,19 @@ def repository(tmp_path, monkeypatch):
     """Build a throwaway repository declaring 0.1.1, and work inside it."""
     (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.1.1"\n')
     (tmp_path / "uv.lock").write_text("version = 1\n")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n"
+        "\n"
+        "## Unreleased\n"
+        "\n"
+        "### Fixed\n"
+        "\n"
+        "- Stop the crash.\n"
+        "\n"
+        "## 0.1.1 - 2026-09-05\n"
+        "\n"
+        "- Shipped.\n"
+    )
     monkeypatch.chdir(tmp_path)
     release.git("init", "-q")
     release.git("config", "user.email", "test@example.com")
@@ -170,3 +183,148 @@ class TestTheRealProjectFile:
     def test_reads_this_project_s_version(self) -> None:
         text = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
         assert release.SEMVER.match(release.read_version(text))
+
+
+class TestSection:
+    """Verify the changelog entry a version answers to."""
+
+    CHANGELOG = (
+        "# Changelog\n"
+        "\n"
+        "## Unreleased\n"
+        "\n"
+        "- Not out yet.\n"
+        "\n"
+        "## 0.1.10 - 2026-10-01\n"
+        "\n"
+        "- The tenth patch.\n"
+        "\n"
+        "## 0.1.1 - 2026-09-05\n"
+        "\n"
+        "- The first patch.\n"
+    )
+
+    def test_reads_the_entry_under_a_version(self) -> None:
+        assert release.section(self.CHANGELOG, "## 0.1.1") == "- The first patch."
+
+    def test_stops_at_the_next_heading(self) -> None:
+        assert release.section(self.CHANGELOG, "## Unreleased") == "- Not out yet."
+
+    def test_a_shorter_version_does_not_answer_for_a_longer_one(self) -> None:
+        """Keep 0.1.1 from reading 0.1.10's entry.
+
+        The two headings share a prefix, so a match that ignored what
+        follows the version would take whichever came first.
+        """
+        assert release.section(self.CHANGELOG, "## 0.1.10") == "- The tenth patch."
+
+    def test_reads_the_last_entry_to_the_end_of_the_file(self) -> None:
+        assert release.section(self.CHANGELOG, "## 0.1.1").endswith("patch.")
+
+    def test_a_version_with_no_entry_reads_as_nothing(self) -> None:
+        assert release.section(self.CHANGELOG, "## 9.9.9") == ""
+
+
+class TestPromote:
+    """Verify what naming an Unreleased heading writes."""
+
+    STARTING = "# Changelog\n\n## Unreleased\n\n- Stop the crash.\n"
+
+    def test_names_the_entries_for_the_version(self) -> None:
+        after = release.promote(self.STARTING, "0.1.2", "2026-09-05")
+        assert "## 0.1.2 - 2026-09-05" in after
+        assert release.section(after, "## 0.1.2") == "- Stop the crash."
+
+    def test_leaves_an_empty_unreleased_heading_above(self) -> None:
+        """Give the next change somewhere to go without anyone making it."""
+        after = release.promote(self.STARTING, "0.1.2", "2026-09-05")
+        assert release.section(after, "## Unreleased") == ""
+        assert after.index("## Unreleased") < after.index("## 0.1.2")
+
+    def test_refuses_a_changelog_with_no_unreleased_heading(self) -> None:
+        with pytest.raises(release.ReleaseError, match="no ## Unreleased"):
+            release.promote("# Changelog\n", "0.1.2", "2026-09-05")
+
+    def test_refuses_an_unreleased_heading_holding_nothing(self) -> None:
+        """A release that says nothing is a forgotten line, not an empty release."""
+        with pytest.raises(release.ReleaseError, match="nothing under"):
+            release.promote(
+                "# Changelog\n\n## Unreleased\n\n## 0.1.1 - 2026-09-05\n\n- Old.\n",
+                "0.1.2",
+                "2026-09-05",
+            )
+
+    def test_names_only_the_first_unreleased_heading(self) -> None:
+        after = release.promote(self.STARTING, "0.1.2", "2026-09-05")
+        assert after.count("## Unreleased") == 1
+
+
+class TestCutWritesTheChangelog:
+    """Verify what a release does to CHANGELOG.md."""
+
+    def test_names_the_entries_for_the_version_it_cuts(self, repository) -> None:
+        release.cut("0.1.2")
+        text = (repository / "CHANGELOG.md").read_text()
+        assert release.section(text, "## 0.1.2") == "### Fixed\n\n- Stop the crash."
+        assert release.section(text, "## Unreleased") == ""
+
+    def test_refuses_a_release_that_says_nothing(self, repository) -> None:
+        (repository / "CHANGELOG.md").write_text("# Changelog\n\n## Unreleased\n")
+        release.git("commit", "-qam", "Empty the changelog")
+        with pytest.raises(release.ReleaseError, match="nothing under"):
+            release.cut("0.1.2")
+
+    def test_a_release_that_says_nothing_writes_no_version(self, repository) -> None:
+        """Leave pyproject.toml alone when the changelog stops the release."""
+        (repository / "CHANGELOG.md").write_text("# Changelog\n\n## Unreleased\n")
+        release.git("commit", "-qam", "Empty the changelog")
+        with pytest.raises(release.ReleaseError):
+            release.cut("0.1.2")
+        assert 'version = "0.1.1"' in (repository / "pyproject.toml").read_text()
+
+    def test_refuses_a_missing_changelog(self, repository) -> None:
+        (repository / "CHANGELOG.md").unlink()
+        release.git("commit", "-qam", "Drop the changelog")
+        with pytest.raises(release.ReleaseError, match="CHANGELOG.md is missing"):
+            release.cut("0.1.2")
+
+    def test_a_declared_version_needs_an_entry_of_its_own(self, repository) -> None:
+        """Refuse to tag a prepared release whose changelog was never named."""
+        (repository / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## Unreleased\n\n- Stop the crash.\n"
+        )
+        release.git("commit", "-qam", "Take the entry away")
+        with pytest.raises(release.ReleaseError, match="no entry for 0.1.1"):
+            release.cut("0.1.1")
+
+    def test_a_declared_version_with_an_entry_is_tagged(self, repository) -> None:
+        assert release.cut("0.1.1") == "0.1.1"
+        assert release.git("tag", "--list", "v0.1.1") == "v0.1.1"
+
+    def test_a_declared_version_leaves_the_changelog_alone(self, repository) -> None:
+        """Name nothing again: the entry was written when the version was set."""
+        before = (repository / "CHANGELOG.md").read_text()
+        release.cut("0.1.1")
+        assert (repository / "CHANGELOG.md").read_text() == before
+
+
+class TestNotes:
+    """Verify the entry the release workflow takes for a release body."""
+
+    def test_prints_the_entry_for_a_version(self, repository, capsys) -> None:
+        (repository / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## 0.1.1 - 2026-09-05\n\n- Shipped.\n"
+        )
+        assert release.main(["--notes", "0.1.1"]) == 0
+        assert capsys.readouterr().out.strip() == "- Shipped."
+
+    def test_a_leading_v_names_the_same_version(self, repository, capsys) -> None:
+        """Take the tag name as the workflow has it, without trimming it first."""
+        (repository / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## 0.1.1 - 2026-09-05\n\n- Shipped.\n"
+        )
+        assert release.main(["--notes", "v0.1.1"]) == 0
+        assert capsys.readouterr().out.strip() == "- Shipped."
+
+    def test_reports_a_version_the_changelog_does_not_name(self, repository) -> None:
+        assert release.main(["--notes", "9.9.9"]) == 1


### PR DESCRIPTION
Build the 0.1.2 milestone: make the release path the only path, and say
what each release gives.

Closes #5, #11, #32, #38, #39, #41. **#12 is not closed here** — see below.

## What each commit does

| commit | issue |
|---|---|
| Keep a changelog | #11 |
| Publish a GitHub release beside the PyPI upload | #38 |
| Group generated release notes by the repository's labels | #39 |
| Refuse a version bump outside a release | #32 |
| Say how to keep generated code out of an index | #5 |
| Say how a release is cut now | — |

## Verified, not assumed

- **The sdist drops CHANGELOG.md without `MANIFEST.in`.** Checked against the
  real 0.1.1 tarball: it held `LICENSE`, `PKG-INFO`, `README.md`,
  `pyproject.toml`, and `setup.cfg`, and nothing else. With `MANIFEST.in` the
  file is in the sdist, and `PKG-INFO` now carries the `Changelog` link, so
  PyPI shows it.
- **`--notes` reads the entry it should.** `--notes 0.1.1` and `--notes v0.1.1`
  print the 0.1.1 entry; a version the file does not name exits 1.
- **`0.1.1` must not answer for `0.1.10`.** The two headings share a prefix, so
  the match requires a space after the version. Pinned by a test.
- **The exclude documentation was run.** `ish "" PATH --no-cache` lists what the
  filter allows, and `--exclude '/generated/'` removes the generated file. The
  first draft named an `--ish --scan` flag that does not exist; it is corrected
  to the invocation that works.
- `poe check` passes: 928 tests, coverage held at 100%.

## What is left for #12

Branch protection is a repository setting, not a file, so it is not in this
pull request. Once this merges, `main` wants:

- a required pull request before merging;
- the `check`, `build`, and the new `version` jobs required to pass;
- no direct push.

The tag-against-`pyproject.toml` check that #12 also names already exists in
`release.yml`.

## Note on the branch name

`milestone/0.1.2`, not `release/0.1.2`. The new `version` job treats a
`release/*` branch as permitted to change the version, and this pull request
should be subject to that check rather than exempt from it. It changes no
version: 0.1.2 is cut with `poe release` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCEmiz5go6hmk2veDCBuh7