### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and the version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## 0.1.2 - 2026-09-05
+
 ### Added
 
 - Keep this changelog. `poe release` names the `Unreleased` heading for the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "interactive-semantic-hunt"
-version = "0.1.1"
+version = "0.1.2"
 description = "Interactive semantic search for code, inspired by fzf"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "interactive-semantic-hunt"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Cut 0.1.2. This pull request carries the version bump and nothing else,
which is the rule #32 added in the release it is cutting.

```
CHANGELOG.md   | 2 ++
pyproject.toml | 2 +-
uv.lock        | 2 +-
```

`poe release 0.1.2` wrote all three: it named the `## Unreleased` heading
for the version and dated it, set the version, brought `uv.lock` in step,
and ran `poe check` before committing.

## Merge this with a merge commit

`poe release` tagged the commit it made. A squash or a rebase would leave
`v0.1.2` naming a commit that is not on `main`, and the tag is what
publishes. After merging:

```sh
git switch main && git pull
git merge-base --is-ancestor v0.1.2 main && echo "the tag is on main"
git push origin v0.1.2
```

Pushing the tag is the decision to publish. Nothing reaches PyPI before
that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCEmiz5go6hmk2veDCBuh7
