### PR TITLE
Let a search answer during an index run

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -181,6 +181,23 @@ The index persists in SQLite, one file per scanned tree, under `$XDG_CACHE_HOME/
   cores. Raising `OLLAMA_NUM_PARALLEL` changes nothing, because Ollama pins an
   embedding model to one slot. Throughput is about 270 tokens per second, so
   chunk size, not concurrency, sets the cost of an index.
+- **The request batch is how long a search waits during an index run.** One
+  slot means a query queues behind the request in flight, and behind that one
+  only. So `DEFAULT_BATCH_SIZE` in the Ollama adapter sets the wait: measured
+  over 64 definitions, 97 s at 64, 23 s at 16, 12 s at 8, while the whole run
+  cost 97.2, 95.8, and 96.9 s. The batch is 8. **It carries no accuracy cost**
+  — each text is embedded on its own, so vectors are bit-identical at every
+  size, verified over 32 texts from 17 to 8,409 characters. Nothing about a
+  stored vector changes, so this needs no `SCHEMA_VERSION` bump.
+- **A query waits a minute; an index run waits ten.** `QUERY_TIMEOUT_SECONDS`
+  is separate from `TIMEOUT_SECONDS` because somebody is watching one of them.
+  A wait of minutes at a picker is a failure to report, not an answer worth
+  serving, and the message names the index run that holds the daemon.
+- Searching during an index run is supported at the storage layer and always
+  was: under WAL a reader is never blocked by a writer. Measured against a
+  writer committing 168k vectors, a second process opened in 0.4 ms, searched
+  in 120 ms, and listed chunks in under 1 ms. When a search feels blocked, the
+  embedding queue is what to look at, not SQLite.
 
 Measured on this repo (33 files, 104 chunks): a cold index costs ~87s with Ollama, ~51s with llama.cpp, which parallelizes bulk embedding better. A warm query costs ~0.20s.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and the version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Answer a search sooner while an index run is going. The daemon serves one
+  embedding request at a time, so a query waits for the request in flight;
+  sending fewer texts per request cuts that wait from about 97 s to about
+  12 s. The whole run costs the same, and the vectors are unchanged.
+
+### Fixed
+
+- Report a busy embedding backend rather than waiting ten minutes for it. A
+  query now says that an index run holds the daemon, and says it in a minute.
+
 ## 0.1.3 - 2026-09-07
 
 ### Fixed

--- a/src/ish/adapters/embedder/ollama.py
+++ b/src/ish/adapters/embedder/ollama.py
@@ -19,11 +19,20 @@ log = logging.getLogger(__name__)
 DEFAULT_HOST = "http://localhost:11434"
 DEFAULT_MODEL = "nomic-embed-text"
 
-# Send this many texts per request. One request for a whole repository
-# would hold the daemon for minutes and risk the timeout.
-DEFAULT_BATCH_SIZE = 64
+# Send this many texts per request. The daemon serves one embedding
+# request at a time, so this is also how long a search waits when an
+# index run is going: a query queues behind the request in flight and
+# nothing else. Measured with nomic-embed-text over 64 definitions, the
+# whole run costs the same at every size while the wait tracks the
+# batch: 97 s at 64, 23 s at 16, 12 s at 8. The vectors are unchanged,
+# bit for bit, so a smaller batch buys the wait for nothing.
+DEFAULT_BATCH_SIZE = 8
 # A batch of large definitions can take minutes on a busy daemon.
 TIMEOUT_SECONDS = 600
+# What somebody watching a picker will wait. A query still queues behind
+# the request an index run has in flight, so it must wait; a wait of
+# minutes is a failure to report rather than an answer worth serving.
+QUERY_TIMEOUT_SECONDS = 60
 
 
 def _normalize_host(host: str) -> str:
@@ -53,19 +62,27 @@ class OllamaEmbedder(PrefixingEmbedder):
         self.host = _normalize_host(chosen)
         self._batch_size = max(1, batch_size)
 
-    def _embed(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+    def _embed(
+        self, texts: Sequence[str], timeout: float = TIMEOUT_SECONDS
+    ) -> Sequence[Sequence[float]]:
         """Encode texts into vectors, one batch of requests at a time."""
         items = list(texts)
         vectors: list[Sequence[float]] = []
         for start in range(0, len(items), self._batch_size):
-            vectors.extend(self._embed_batch(items[start : start + self._batch_size]))
+            vectors.extend(
+                self._embed_batch(items[start : start + self._batch_size], timeout)
+            )
         return vectors
+
+    def _embed_interactive(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        """Encode a query, waiting only as long as a person will."""
+        return self._embed(texts, timeout=QUERY_TIMEOUT_SECONDS)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _embed_batch(self, batch: list[str]) -> list[Sequence[float]]:
+    def _embed_batch(self, batch: list[str], timeout: float) -> list[Sequence[float]]:
         """Send one batch and return its vectors."""
         payload = json.dumps({"model": self.model_name, "input": batch}).encode("utf-8")
         request = urllib.request.Request(
@@ -75,8 +92,14 @@ class OllamaEmbedder(PrefixingEmbedder):
         )
 
         try:
-            with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 body = json.loads(response.read())
+        except TimeoutError as exc:
+            raise RuntimeError(
+                f"Ollama at {self.host} did not answer within {timeout:g} s. "
+                f"It serves one embedding request at a time, so a query waits "
+                f"for the batch an index run has in flight."
+            ) from exc
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", "replace").strip()
             if exc.code == 404:

--- a/src/ish/adapters/embedder/prefixes.py
+++ b/src/ish/adapters/embedder/prefixes.py
@@ -74,7 +74,7 @@ class PrefixingEmbedder:
             return held
 
         _, prefix = prefixes_for(self.model_name)
-        vectors = self._embed([f"{prefix}{text}" if prefix else text])
+        vectors = self._embed_interactive([f"{prefix}{text}" if prefix else text])
         vector = vectors[0] if vectors else []
 
         cache[text] = vector
@@ -85,3 +85,11 @@ class PrefixingEmbedder:
     def _embed(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
         """Encode already-prepared texts. Implemented by each adapter."""
         raise NotImplementedError
+
+    def _embed_interactive(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        """Encode text a person is waiting for.
+
+        Take the same path as a stored text. A backend that can wait
+        differently for a request somebody is watching overrides this.
+        """
+        return self._embed(texts)

--- a/tests/unit/adapters/test_ollama.py
+++ b/tests/unit/adapters/test_ollama.py
@@ -133,6 +133,67 @@ class TestEmbed:
         OllamaEmbedder(batch_size=0).embed_documents(["a", "b"])
         assert [len(r["input"]) for r in recorder.requests] == [1, 1]
 
+    def test_the_default_batch_keeps_a_request_short(
+        self, recorder: Recorder
+    ) -> None:
+        """The daemon serves one request at a time.
+
+        A batch is therefore how long a search waits while an index run
+        is going, so the default splits rather than sending everything
+        as one request nothing can queue ahead of.
+        """
+        OllamaEmbedder().embed_documents([f"text {n}" for n in range(64)])
+
+        assert len(recorder.requests) > 1
+        assert max(len(r["input"]) for r in recorder.requests) <= 8
+
+
+class TestWaiting:
+    """Verify that a query does not wait as long as an index run."""
+
+    class TimingRecorder(Recorder):
+        """Record the timeout asked of each request."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.timeouts: list[float] = []
+
+        def __call__(self, request, timeout=None):
+            self.timeouts.append(timeout)
+            return super().__call__(request, timeout=timeout)
+
+    def _record(self, monkeypatch) -> "TestWaiting.TimingRecorder":
+        rec = self.TimingRecorder()
+        monkeypatch.setattr(urllib.request, "urlopen", rec)
+        return rec
+
+    def test_a_query_waits_less_than_a_stored_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rec = self._record(monkeypatch)
+        embedder = OllamaEmbedder("all-minilm")
+
+        embedder.embed_documents(["stored"])
+        embedder.embed_query("asked")
+
+        stored, asked = rec.timeouts
+        assert asked < stored
+
+    def test_a_slow_daemon_is_reported_rather_than_waited_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(request, timeout=None):  # noqa: ARG001
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            OllamaEmbedder().embed_query("anything")
+
+        message = str(exc_info.value)
+        assert "did not answer" in message
+        assert "one embedding request at a time" in message
+
 
 class TestFailures:
     """Verify that every failure explains what to do next."""


### PR DESCRIPTION
Searching during an index run was already supported everywhere — the storage layer, the TUI, MCP, and nvim, which calls `server.refresh()` and then searches anyway. It just did not *feel* supported, because a query waited about 97 s. This makes the wait about 12 s at no cost.

## Where the wait actually was

Not SQLite. Under WAL a reader is never blocked by a writer, and against a process committing 168k vectors a second process opened in 0.4 ms, searched in 120 ms, and listed chunks in under 1 ms.

It was the embedding backend. Ollama serves one embedding request at a time, so a query queues behind the request in flight — and behind that one only. The request batch was therefore the entire wait:

```
batch_size= 64  query waited  96729.6 ms   (whole 64-chunk run:   97.2 s)
batch_size= 16  query waited  23497.3 ms   (whole 64-chunk run:   95.8 s)
batch_size=  8  query waited  11763.6 ms   (whole 64-chunk run:   96.9 s)
```

The wait is linear in the batch and **the throughput is unchanged** — 97.2 / 95.8 / 96.9 s is noise. Embedding is token-bound rather than request-bound, which is why the extra round trips cost nothing measurable.

## No accuracy cost

Each text is embedded on its own, so the batch does not change the vectors:

```
batch_size=  8 vs 1:  min cos 1.000000000   bit-identical 32/32
batch_size= 16 vs 1:  min cos 1.000000000   bit-identical 32/32
batch_size= 64 vs 1:  min cos 1.000000000   bit-identical 32/32
```

Verified over 32 texts from 17 to 8,409 characters, so any batch-wide padding or truncation would have shown. Identical bytes mean identical ranking, so the retrieval benchmark cannot move and `SCHEMA_VERSION` does not need a bump. No re-index.

Confirmed against the real daemon after the change: query wait **96.7 s → 11.5 s**, run 97.2 s → 97.8 s, vectors 8/8 bit-identical.

## A query no longer waits ten minutes

`TIMEOUT_SECONDS` is 600, which is right for a batch of large definitions and wrong for somebody at a picker. `QUERY_TIMEOUT_SECONDS` is 60, and the message names the index run holding the daemon rather than claiming the host is unreachable.

`_embed_interactive()` on `PrefixingEmbedder` defaults to the ordinary path, so the llama.cpp and sentence-transformers backends are untouched. Only the Ollama adapter overrides it.

## Checks

`poe check` passes: 938 tests, coverage 100.00%.

## Note on #53

That issue asks for a SQLite `busy_timeout`. The measurements above say SQLite was not what blocked — reads resolve in sub-milliseconds under a sustained writer. The embedding queue fits the reported evidence better: two runs competing for one slot, both at 0 CPU waiting on HTTP, and tree B progressing the moment tree A stopped. I will add the numbers there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCEmiz5go6hmk2veDCBuh7