### PR TITLE
Release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and the version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## 0.1.4 - 2026-09-07
+
 ### Changed
 
 - Answer a search sooner while an index run is going. The daemon serves one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "interactive-semantic-hunt"
-version = "0.1.3"
+version = "0.1.4"
 description = "Interactive semantic search for code, inspired by fzf"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "interactive-semantic-hunt"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Cut from `main`, which holds the 0.1.3 release plus #56 and nothing else — `git diff v0.1.3 main` was empty before that merge, so this patch carries one change and no half-built work.

## What ships

Searching during an index run was already supported everywhere — the storage layer, the TUI, MCP, and nvim. It just did not feel supported, because a query waited about 97 s behind the embedding backend. Ollama serves one embedding request at a time, so a query queues behind the request in flight and behind that one only; the request batch was therefore the whole wait.

Sending 8 texts per request instead of 64 cuts it to about 12 s. Measured against the live daemon after the change: **96.7 s → 11.5 s**, whole run 97.2 s → 97.8 s.

- **No throughput cost.** 97.2 / 95.8 / 96.9 s for the same 64 definitions at batch 64 / 16 / 8. Embedding is token-bound, not request-bound.
- **No accuracy cost.** Each text is embedded on its own, so vectors are bit-identical at every batch size — 32/32 over texts from 17 to 8,409 characters. Identical bytes mean identical ranking.
- **No re-index.** Nothing about what a stored vector means changes, so `SCHEMA_VERSION` is untouched.

A query also gets its own 60 s timeout, separate from the 600 s one a bulk batch needs, and the message names the index run holding the daemon rather than claiming the host is unreachable.

## Merge

With a merge commit. `poe release` tagged `v0.1.4` on this branch, so a squash or a rebase would leave the tag naming a commit that is not on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCEmiz5go6hmk2veDCBuh7